### PR TITLE
feat(#002): Add GitHub Packages publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  JAVA_VERSION: '21'
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Publish to GitHub Packages
+        run: mvn deploy -B -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -14,6 +14,7 @@ We use a dual numbering system to separate internal development tracking from pu
 | Internal | Public | Title | Status | Priority | Type | Labels |
 | -------- | ------ | ----- | ------ | -------- | ---- | ------ |
 | #001 | - | Github packages | 📋 Open | Medium | Feature | |
+| #002 | [GH#6](https://github.com/cassandragargoyle/api/issues/6) | GitHub Packages publishing workflow | 📋 Open | Medium | Feature | ci, maven, github |
 
 ## Directory Structure
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,14 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/cassandragargoyle/api</url>
+		</repository>
+	</distributionManagement>
+
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
## Summary

- Add `distributionManagement` section to `pom.xml` for GitHub Packages
- Create `publish.yml` GitHub Actions workflow triggered on `v*` tag pushes
- Workflow uses JDK 21 (Temurin), caches Maven dependencies, and runs `mvn deploy`

## Related

Closes #6

## Test plan

- [ ] Verify `pom.xml` has correct `distributionManagement` configuration
- [ ] Verify `publish.yml` workflow syntax is valid
- [ ] Create a `v*` tag and confirm workflow triggers
- [ ] Confirm artifact is published to GitHub Packages