### PR TITLE
fix(#002): Strip -SNAPSHOT versions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Strip SNAPSHOT versions
+        run: find . -name pom.xml -exec sed -i 's/-SNAPSHOT//g' {} +
+
       - name: Publish to GitHub Packages
         run: mvn deploy -B -DskipTests
         env:

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -14,7 +14,7 @@ We use a dual numbering system to separate internal development tracking from pu
 | Internal | Public | Title | Status | Priority | Type | Labels |
 | -------- | ------ | ----- | ------ | -------- | ---- | ------ |
 | #001 | - | Github packages | 📋 Open | Medium | Feature | |
-| #002 | [GH#6](https://github.com/cassandragargoyle/api/issues/6) | GitHub Packages publishing workflow | 📋 Open | Medium | Feature | ci, maven, github |
+| #002 | [GH#6](https://github.com/cassandragargoyle/api/issues/6) | GitHub Packages publishing workflow | ✅ Implemented | Medium | Feature | ci, maven, github |
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary

- Add workflow step to strip `-SNAPSHOT` suffix from pom.xml versions before `mvn deploy`
- Update issue #002 status to Implemented

## Related

Relates to #6

## Test plan

- [ ] Merge this PR
- [ ] Create and push tag `v1.0.0.3`
- [ ] Verify publish workflow strips -SNAPSHOT and deploys correct version