### PR TITLE
chore(issues): adopt GitHub-first issue workflow and align numbering

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: create-issue
+description: 'Create a new issue GitHub-first — the GitHub issue is created first (GitHub assigns the number), then a detailed write-up is added to docs/issues/internal/N-*.md. Use when the user wants to create/open an issue, feature request, or bug. Examples: "open an issue …", "/create-issue typescript preferences store", "create an issue for …".'
+argument-hint: [short issue description]
+allowed-tools: Read, Glob, Grep, Bash, AskUserQuestion, Write, Edit
+user-invocable: true
+---
+
+# Create issue (GitHub-first)
+
+Create a new issue in the Api project.
+
+**Argument:** $ARGUMENTS
+
+## Principle
+
+**GitHub is the single source of truth for the issue list.** GitHub assigns the
+number on creation. The GitHub issue holds only the *basics* (title + short
+description + link to the detail file). Details live in
+`docs/issues/internal/N-*.md`, where `N` = the GitHub issue number.
+
+**No overview tables** — the list lives on GitHub.
+Full methodology: `docs/contributing/ISSUE-MANAGEMENT.md`.
+
+## Instructions
+
+### STEP 1: Gather inputs
+
+From the argument / context (or via `AskUserQuestion` if missing) determine:
+
+- **Title** — short, descriptive, in English (no number; GitHub adds it)
+- **Slug** — kebab-case for the filename (derive from the title, e.g. `typescript-preferences-store`)
+- **Type**: Feature | Enhancement | Bug Fix | Security | Task
+- **Priority**: Critical | High | Medium | Low
+- **Component** — by top-level module: `java`, `python`, `go`, `typescript`,
+  `contract`; cross-cutting: `build-infra`, `core`, `docs`. Issues are filtered
+  by this label (`label:typescript`)
+- **Short description** (1–3 sentences) — goes into the GitHub issue body
+- **Detailed content** — goes into the local `.md` (problem, steps, acceptance criteria, tests)
+
+All text in **English** (project convention).
+
+### STEP 2: Preflight — check `gh`
+
+```bash
+gh --version && gh auth status
+```
+
+If not authenticated, stop and prompt the user: `gh auth login` (feel free to use the `!` prefix).
+
+### STEP 3: Create the GitHub issue (GitHub assigns the number)
+
+Keep the body **minimal** — short description + a link placeholder (filled in at STEP 5):
+
+```bash
+REPO="cassandragargoyle/api"
+gh issue create --repo "$REPO" \
+  --title "<TITLE>" \
+  --body "<SHORT DESCRIPTION>
+
+📄 Full details: docs/issues/internal/<N>-<slug>.md" \
+  [--label <type>,<priority>,<component>]
+```
+
+`gh issue create` prints the URL — take the **number `N`** from it
+(`.../issues/7` → `N=7`). Only pass labels that already exist on GitHub;
+otherwise create them first (`gh label create <name> --repo "$REPO" --color 1d76db`).
+
+### STEP 4: Write the detail file
+
+Create `docs/issues/internal/<N>-<slug>.md` with the full content. Skeleton:
+
+```markdown
+# Issue #<N>: <Title>
+
+**Type**: <type>
+**Priority**: <priority>
+**Status**: 📋 Open
+**Created**: <YYYY-MM-DD>
+**GitHub**: #<N>
+**Component**: <component>
+**Related**: #<...>, ADR-<...>
+
+## Summary
+<1–3 sentences>
+
+## Problem Description / Motivation
+...
+
+## Scope
+### In scope
+### Out of scope (follow-up issues)
+
+## Acceptance Criteria
+1. ...
+
+## Testing
+...
+```
+
+### STEP 5: Add the exact link back to the GitHub issue
+
+Now that `N` and the filename are known, update the body with a working link
+(blob URL on `main`):
+
+```bash
+URL="https://github.com/$REPO/blob/main/docs/issues/internal/<N>-<slug>.md"
+gh issue edit <N> --repo "$REPO" \
+  --body "<SHORT DESCRIPTION>
+
+📄 [Full details](${URL})"
+```
+
+> The link starts working once the file is on `main`.
+
+### STEP 6: Summary
+
+Show the user:
+
+```text
+Issue #<N> created.
+
+GitHub:  https://github.com/cassandragargoyle/api/issues/<N>
+Detail:  docs/issues/internal/<N>-<slug>.md
+Type/Priority: <type> / <priority>
+
+Next steps:
+  git switch -c feat/<N>-<slug>
+  # commit:  feat(#<N>): <title>   (closes via: closes #<N>)
+```
+
+## Notes
+
+- **Never invent** the number — GitHub always assigns it. GitHub issues and PRs
+  share one counter, so numbers may skip.
+- To archive a finished issue: `gh issue close <N>` +
+  `git mv docs/issues/internal/<N>-*.md docs/issues/internal/done/`.
+- Legacy internal numbers `001`–`017` (in `done/`) were never mirrored to GitHub —
+  they exist for history only.

--- a/.claude/skills/create-manifest/SKILL.md
+++ b/.claude/skills/create-manifest/SKILL.md
@@ -1,41 +1,41 @@
 ---
 name: create-manifest
-description: Vytvoří software manifest podle metodiky projektu. Použij, když chce uživatel vytvořit manifest pro software, nástroj nebo technologii.
+description: Create a software manifest following the project methodology. Use when the user wants to create a manifest for a piece of software, a tool, or a technology.
 ---
 
-# Vytvoření software manifestu
+# Create a software manifest
 
-Tvým úkolem je vytvořit software manifest pro zadanou položku (název software, nástroje nebo technologie).
+Your task is to create a software manifest for the given item (a software, tool, or technology name).
 
-## KROK 1: Zjisti položku
+## STEP 1: Determine the item
 
-Pokud uživatel nezadal položku, zeptej se česky:
+If the user did not provide an item, ask:
 
-> Pro jaký software, nástroj nebo technologii chceš vytvořit manifest?
+> What software, tool, or technology do you want to create a manifest for?
 
-Počkej na odpověď uživatele a poté pokračuj.
+Wait for the user's answer, then continue.
 
-## KROK 2: Nastuduj metodiku
+## STEP 2: Study the methodology
 
-Přečti si `docs/manifests/README.md` pro pochopení struktury a konvencí manifestů.
+Read `docs/manifests/README.md` to understand the structure and conventions of manifests.
 
-## KROK 3: Prozkoumej existující manifesty
+## STEP 3: Review existing manifests
 
-Podívej se na existující manifesty v `docs/manifests/` pro inspiraci formátem a obsahem (např. `manifest-docker.md`, `manifest-go.md`).
+Look at existing manifests in `docs/manifests/` for inspiration on format and content (e.g. `manifest-docker.md`, `manifest-go.md`).
 
-## KROK 4: Vyhledej informace
+## STEP 4: Research the information
 
-Použij web search pro získání aktuálních informací o:
+Use web search to gather up-to-date information about:
 
-- Aktuální verze a release date
-- Oficiální dokumentace a website
-- Licenční podmínky
+- Current version and release date
+- Official documentation and website
+- License terms
 - System requirements
-- Hlavní use cases
+- Main use cases
 
-## KROK 5: Vytvoř manifest
+## STEP 5: Create the manifest
 
-Vytvoř soubor `docs/manifests/manifest-{název}.md` obsahující:
+Create the file `docs/manifests/manifest-{name}.md` containing:
 
 - Basic Information (name, category, license, version, maintainer, investment type)
 - Installation Details
@@ -43,17 +43,17 @@ Vytvoř soubor `docs/manifests/manifest-{název}.md` obsahující:
 - Dependencies
 - Portunix Integration
 - Verification commands
-- Best Use Cases (✅ doporučené, ⚠️ nedoporučené)
+- Best Use Cases (✅ recommended, ⚠️ not recommended)
 - Community & Metrics
 - Learning Resources
 
-## KROK 6: Aktualizuj README
+## STEP 6: Update the README
 
-Přidej nový manifest do seznamu v `docs/manifests/README.md` na správné místo podle kategorie.
+Add the new manifest to the list in `docs/manifests/README.md` in the correct place by category.
 
-## Konvence
+## Conventions
 
-- Použij ikony podle typu investice: 📈 (veřejně obchodovaná), 🔒 (privátní), 🆓 (open-source)
-- Použij ✅ pro doporučené use cases a ⚠️ pro případy kdy zvážit alternativy
-- Dodržuj anglický jazyk v obsahu manifestu (projekt má anglickou dokumentaci)
-- Název souboru: `manifest-{kebab-case-název}.md`
+- Use icons by investment type: 📈 (publicly traded), 🔒 (private), 🆓 (open-source)
+- Use ✅ for recommended use cases and ⚠️ for cases where alternatives should be considered
+- Keep the manifest content in English (the project uses English documentation)
+- Filename: `manifest-{kebab-case-name}.md`

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -80,17 +80,23 @@ Povolené typy: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 
 **STOP** - Zeptej se mě na potvrzení commit message před commitnutím.
 
-## KROK 6: Push a PR (volitelný)
+## KROK 6: Push a PR
 
-Pokud má issue propojený GitHub issue:
+`origin` je GitHub (`cassandragargoyle/api`). Číslo issue = číslo GitHub issue.
 
-1. Push branch na Gitea: `git push origin <branch>`
-2. Nabídni přípravu pro GitHub PR přes publish skripty (`scripts/github_02_sync_publish.py`)
-3. Připrav PR popis ve formátu:
-   - Název: stručný popis změny
-   - Tělo: summary, test plan, odkaz na GitHub issue (`Closes #N`)
+1. Push branch: `git push -u origin <branch>`
+2. Otevři PR přes `gh` a propoj issue přes `Closes #N`:
 
-Pokud issue nemá GitHub propojení, stačí push na Gitea.
+   ```bash
+   gh pr create --repo cassandragargoyle/api \
+     --title "<type>(#N): <krátké shrnutí>" \
+     --body "Summary …
+
+   Test plan …
+
+   Closes #N"
+   ```
+3. Alternativa bez PR: merge přímo do `main` po review (viz Další kroky).
 
 ---
 
@@ -98,7 +104,11 @@ Pokud issue nemá GitHub propojení, stačí push na Gitea.
 
 Po dokončení implementace:
 
-- Merge branch do main: `git checkout main && git merge <branch>`
+- Sloučení: přes merge PR na GitHubu, nebo lokálně
+  `git checkout main && git merge <branch> && git push origin main`
 - Smazání feature branch: `git branch -d <branch>`
-- Aktualizuj stav issue v `docs/issues/internal/` na `Status: Implemented`
-- Aktualizuj tabulku v `docs/issues/README.md` na ✅ Implemented
+- Uzavři issue: `gh issue close N` (nebo automaticky přes `Closes #N` v PR)
+- Archivuj detailní soubor:
+  `git mv docs/issues/internal/N-*.md docs/issues/internal/done/`
+
+Seznam issues je na GitHubu — **žádné přehledové tabulky se needitují.**

--- a/docs/contributing/ISSUE-MANAGEMENT.md
+++ b/docs/contributing/ISSUE-MANAGEMENT.md
@@ -1,179 +1,148 @@
+---
+title: Issue Management
+description: Workflow for creating, tracking, and archiving issues in Api — GitHub-first, where GitHub assigns the number and each issue keeps a long-form mirror in docs/issues/internal/N-*.md (archived to done/ on completion). No overview tables.
+category: contributing-guide
+status: active
+language: en
+last_updated: 2026-07-19
+---
+
 # Issue Management for Api
 
-## Overview
+## Principle: GitHub-First
 
-This document outlines how issues are managed in the Api project.
+**GitHub is the single source of truth for the issue list.** The issue is
+created on GitHub first, so **GitHub assigns the number `N`**. The GitHub issue
+carries only the *basics* — a short description plus a link to the detail file.
+The full write-up lives in the repo at `docs/issues/internal/N-name.md`, where
+the filename number **equals the GitHub issue number**.
 
-## Issue Types
+> There are **no overview tables** in `docs/issues/` — a shared Markdown table
+> edited by everyone caused constant merge conflicts and was removed. Status,
+> assignee, labels, and milestone live on GitHub; the repo keeps only the
+> long-form write-up per issue.
 
-### Bug Reports
-
-- Software defects and errors
-- Performance issues
-- Security vulnerabilities
-- Regression bugs
-
-### Feature Requests
-
-- New functionality proposals
-- Enhancement suggestions
-- API improvements
-- User experience improvements
-
-### Tasks
-
-- Development tasks
-- Documentation updates
-- Maintenance work
-- Infrastructure changes
-
-## Labels and Categories
-
-### Type Labels
-
-- `bug` - Bug reports
-- `enhancement` - Feature requests
-- `task` - General tasks
-- `documentation` - Documentation issues
-- `question` - Questions and discussions
-
-### Priority Labels
-
-- `critical` - Urgent fixes needed
-- `high` - High priority
-- `medium` - Normal priority
-- `low` - Low priority, nice to have
-
-### Status Labels
-
-- `needs-triage` - Requires initial review
-- `in-progress` - Currently being worked on
-- `blocked` - Cannot proceed due to dependencies
-- `ready-for-review` - Ready for code review
-- `needs-info` - More information required
+The `/create-issue` skill automates this flow.
 
 ## Workflow
 
-### 1. Issue Creation
+1. **Create the GitHub issue** (GitHub assigns `N`). Keep the body minimal —
+   a one-line summary plus a link placeholder:
 
-- Create file `docs/issues/internal/{number}-{short-title}.md` (active location)
-- **Next number**: assign one greater than the highest number anywhere under
-  `docs/issues/internal/` **including the `internal/done/` archive** (completed
-  issues are moved there but keep their number). Scanning only the active
-  directory reuses a number already taken by an archived issue — always list
-  `done/` before allocating.
-- Add a row to the **Active** table in `docs/issues/README.md`
-- Use appropriate template
-- Add relevant labels
-- Assign to milestone if applicable
-- Provide clear description
+   ```bash
+   gh issue create --repo cassandragargoyle/api \
+     --title "Short descriptive title" \
+     --body "One-line summary.
 
-### 2. Triage Process
+   📄 Full details: docs/issues/internal/N-name.md" \
+     [--label <type>,<priority>,<component>]
+   ```
 
-- Review new issues weekly
-- Assign priority and labels
-- Add to appropriate project board
-- Assign team members if needed
+   `gh issue create` prints the URL — take `N` from it (`.../issues/7` → `N=7`).
+   Never invent a number. GitHub issues and pull requests share one counter, so
+   numbers may skip where a PR consumed one.
 
-### 3. Development
+2. **Write the detail file** `docs/issues/internal/N-name.md` (problem,
+   acceptance criteria, testing, related issues). Use `N` in the filename and in
+   the `# Issue #N:` heading.
 
-- Link pull requests to issues
-- Update issue status regularly
-- Communicate blockers promptly
-- Document decisions and changes
+3. **Update the GitHub body** with a working link once `N` and the filename are
+   known (blob URL on `main`):
 
-### 4. Closure
+   ```bash
+   gh issue edit N --repo cassandragargoyle/api \
+     --body "One-line summary.
 
-- Verify fix or implementation
-- Update documentation if needed
-- Close with appropriate comment
-- Reference in release notes
-- **Archive the issue file**: as the last step, move the issue file
-  to the `done/` subfolder —
-  `git mv docs/issues/internal/{file}.md docs/issues/internal/done/`
-  — and move its row from the **Active** to the **Done** table in
-  `docs/issues/README.md` (update the link path to `internal/done/...`).
-  Commit the archive move together with the status change.
+   📄 [Full details](https://github.com/cassandragargoyle/api/blob/main/docs/issues/internal/N-name.md)"
+   ```
 
-## Directory Layout
+4. **Reference `N`** in branches and commits: `feat/N-name`, `feat(#N): …`,
+   `closes #N`.
 
-Active issues (`new`, `open`, `in-progress`, `blocked`, `on-hold`) live in
-`docs/issues/internal/`. Completed issues (`implemented`, `closed`) are
-archived in `docs/issues/internal/done/`. The README table at
-`docs/issues/README.md` remains the single human entry point and links
-to whichever location each file currently occupies.
+5. **Archive on completion**: `gh issue close N` and
+   `git mv docs/issues/internal/N-name.md docs/issues/internal/done/`.
 
-Rationale: keeps `ls docs/issues/internal/` focused on active work
-without fragmenting the archive by status or year. See
-`docs/issues/README.md` for the full description.
-
-## Templates
-
-### Bug Report Template
+## Detail file template
 
 ```markdown
-**Bug Description**
-Brief description of the issue
+# Issue #N: <Title>
 
-**Environment**
-- OS: [e.g. Ubuntu 20.04]
-- Version: [e.g. v1.2.3]
-- Browser: [if applicable]
+**Type**: Feature | Enhancement | Bug Fix | Security | Task
+**Priority**: Critical | High | Medium | Low
+**Status**: 📋 Open
+**Created**: <YYYY-MM-DD>
+**GitHub**: #N
+**Component**: <java | python | go | typescript | contract | build-infra | core | docs>
+**Related**: #<...>, ADR-<...>
 
-**Steps to Reproduce**
-1. Step one
-2. Step two
-3. ...
+## Summary
+<1–3 sentences>
 
-**Expected Behavior**
-What should happen
+## Problem Description / Motivation
+...
 
-**Actual Behavior**
-What actually happens
+## Scope
+### In scope
+### Out of scope (follow-up issues)
 
-**Additional Context**
-Any other relevant information
+## Acceptance Criteria
+1. ...
+
+## Testing
+...
 ```
 
-### Feature Request Template
+## Labels
 
-```markdown
-**Feature Description**
-Clear description of the requested feature
+Assign labels on the GitHub issue (create them once with `gh label create`):
 
-**Use Case**
-Why is this feature needed?
+- **Type**: `bug`, `enhancement`, `documentation`, `question`, `task`
+- **Priority**: `critical`, `high`, `medium`, `low`
+- **Component** — one per language module or area, matching the top-level
+  directory: `java`, `python`, `go`, `typescript`, `contract`. Cross-cutting
+  areas use `build-infra`, `core`, or `docs`. This is how issues are filtered:
 
-**Proposed Solution**
-How should this be implemented?
+  ```text
+  is:issue is:open label:typescript
+  ```
 
-**Alternatives Considered**
-Other approaches you've considered
+- **Status** (optional): `needs-triage`, `in-progress`, `blocked`,
+  `ready-for-review`
+- **Platform** (optional): `windows`, `linux`, `macos`, `cross-platform`
 
-**Additional Context**
-Screenshots, mockups, or examples
+Create a component label once:
+
+```bash
+gh label create typescript --repo cassandragargoyle/api \
+  --color 1d76db --description "Issues for the TypeScript module"
 ```
 
-## Best Practices
+## File structure
 
-### For Contributors
+```text
+docs/issues/
+├── README.md                 # Process pointer only — NO overview table
+└── internal/                 # Active issue detail files (N = GitHub issue number)
+    ├── N-name.md             # Long-form write-up
+    └── done/                 # Archived (✅ Implemented / ❌ Closed) issues
+        └── N-*.md
+```
 
-- Search existing issues before creating new ones
-- Provide complete information
-- Follow issue templates
-- Be respectful and constructive
-- Update issues with progress
+## Numbering note
 
-### For Maintainers
+- Filenames from the adoption of this model onward use the **GitHub issue
+  number** `N`. Legacy internal-only numbers (`001`–`017`, in `done/`) were
+  never mirrored to GitHub and are kept for history only.
+- Never invent a number — always take the one GitHub returns.
 
-- Respond to issues promptly
-- Provide clear feedback
-- Use consistent labeling
-- Keep issues organized
-- Close stale issues appropriately
+## Best practices
+
+- Search existing GitHub issues before opening a new one.
+- Keep the GitHub body short; put depth in the detail file.
+- Assign type + priority + component labels immediately.
+- Include reproduction steps for bugs and acceptance criteria for features.
+- All issue text in **English** (project convention).
 
 ---
 
-*Effective issue management helps maintain project quality and team productivity.*
-*Last updated: 2026-04-03*
-*Maintained by: Api Team*
+*Last updated: 2026-07-19 — switched to the GitHub-first model (Model A); removed overview tables and local-first numbering.*

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,127 +1,39 @@
 # Issues Documentation & Tracking
 
-This directory contains detailed documentation for all issues, feature requests, and development planning.
+**GitHub is the single source of truth for the issue list.**
+See <https://github.com/cassandragargoyle/api/issues>.
 
-## Dual Numbering System
+This directory holds only the **long-form write-up** for each issue. There are
+**no overview tables** here — status, assignee, labels, and milestone live on
+GitHub. A shared Markdown table edited by everyone caused constant merge
+conflicts and was removed.
 
-We use a dual numbering system to separate internal development tracking from public GitHub issues:
+## Model: GitHub-First
 
-- **Internal**: All issues (bugs, security, features) tracked in `internal/` with sequential numbering (#001, #002, etc.)
-- **Public**: Selected features and enhancements published to GitHub with PUB- prefix (PUB-001, PUB-002, etc.)
+The issue is created on GitHub first, so **GitHub assigns the number `N`**. The
+GitHub issue carries only a short description plus a link to the detail file. The
+full write-up lives at `docs/issues/internal/N-name.md`, where the filename
+number **equals the GitHub issue number**.
+
+The `/create-issue` skill automates this flow. Full methodology:
+[`docs/contributing/ISSUE-MANAGEMENT.md`](../contributing/ISSUE-MANAGEMENT.md).
 
 ## Directory Layout
 
-- Active issues (`new`, `open`, `in-progress`, `blocked`, `on-hold`) live in `docs/issues/internal/`.
-- Completed issues (`implemented`, `closed`) are archived in `docs/issues/internal/done/` — moved there as the last step of issue close.
-
-## Internal Issues — Active
-
-| Internal | Public | Title | Status | Priority | Type | Labels |
-| -------- | ------ | ----- | ------ | -------- | ---- | ------ |
-| [#013](internal/013-typescript-preferences.md) | - | User preferences storage — TypeScript first implementation | 📋 Open | Medium | Feature | typescript, react, preferences, settings, multi-language |
-
-## Internal Issues — Done
-
-| Internal | Public | Title | Status | Priority | Type | Labels |
-| -------- | ------ | ----- | ------ | -------- | ---- | ------ |
-| [#017](internal/done/017-product-vendor-ownership.md) | - | Product schema — optional vendor / owner organization reference | ✅ Implemented | Medium | Enhancement | contract, schema, product, opportunity-management, federation |
-| [#016](internal/done/016-discussion-contract-v3-structured.md) | - | Discussion contract v3.0.0 — structured, multi-actor threads | ✅ Implemented | Medium | Feature | contract, schema, discussion, multi-actor, provenance, breaking-change |
-| [#015](internal/done/015-opportunity-management-v2-entities.md) | - | Opportunity Management v2 — Venture/Initiative/Use-Case/Epic/Team/Product contracts | ✅ Implemented | Medium | Feature | contract, schema, opportunity-management, use-case, iso16355, pft |
-| [#014](internal/done/014-opportunity-management-contracts.md) | - | Opportunity Management contract schemas | 🗄️ Archived (superseded by #015) | Medium | Feature | contract, schema, opportunity-management, iso16355, pft |
-| [#012](internal/done/012-typescript-log-module.md) | - | Add TypeScript (`typescript/`) module with `log` package | ✅ Implemented | Medium | Feature | typescript, react, log, logging, multi-language |
-| [#011](internal/done/011-graph-view-contract.md) | - | Graph View Contract: JSON Schema + file extension for the 3D node-graph viewer | ✅ Implemented | Medium | Feature | contract, schema, graph, visualization |
-| [#001](internal/done/001-github%20packages.md) | - | Github packages (design rationale) | ✅ Documented | Medium | Feature | architecture, maven, github-packages |
-| [#002](internal/done/002-github-packages-publishing.md) | [GH#6](https://github.com/cassandragargoyle/api/issues/6) | GitHub Packages publishing workflow | ✅ Implemented | Medium | Feature | ci, maven, github |
-| [#003](internal/done/003-fix-persistance-typo.md) | - | Fix "persistance" typo to "persistence" | ✅ Implemented | Low | Bug Fix | refactoring, naming |
-| [#004](internal/done/004-opentelemetry-telemetry-provider.md) | - | OpenTelemetry TelemetryProvider utility class | ✅ Implemented | Medium | Feature | observability, opentelemetry, tracing |
-| [#005](internal/done/005-python-telemetry-provider.md) | - | Python TelemetryProvider shared module | ✅ Implemented | Medium | Feature | observability, opentelemetry, tracing, python |
-| [#006](internal/done/006-restructure-multi-language-layout-mvp.md) | - | Restructure multi-language layout + MVP contracts | ✅ Implemented | High | Feature | architecture, restructuring, mvp, unified-platform |
-| [#007](internal/done/007-remove-persistence-module.md) | - | Remove persistence module | ✅ Implemented | Medium | Feature | architecture, cleanup, unified-platform |
-| [#008](internal/done/008-python-build-and-publish-pipeline.md) | - | Python build and publish pipeline | ✅ Implemented | Medium | Feature | python, ci, build, distribution |
-| [#009](internal/done/009-plugin-platform-contract-schemas.md) | - | Plugin Platform Contract Schemas | ✅ Implemented | High | Feature | architecture, contract, plugin-platform |
-| [#010](internal/done/010-fuzzy-package-levenshtein.md) | - | Add `fuzzy` package with Levenshtein distance (Java, Go, Python) | ✅ Implemented | Medium | Feature | feature, fuzzy, algorithms, java, go, python, multi-language |
-
-## Public Issues
-
-_No public-only issues yet._
-
-## Directory Structure
-
 ```text
 docs/issues/
-├── README.md              # This file - main tracking table
-├── internal/              # Active internal issues (not yet closed)
-│   ├── 001-*.md
-│   └── done/              # Archive of completed (implemented/closed) issues
-│       ├── 002-*.md
-│       └── ...
-└── public/
-    └── mapping.json       # Mapping between internal and public issue numbers
+└── internal/                 # Active issue detail files (N = GitHub issue number)
+    ├── N-name.md             # Long-form write-up
+    └── done/                 # Archived issues (moved here on close)
+        └── N-*.md
 ```
 
-## Usage
+- Active issues live in `docs/issues/internal/`.
+- On completion: `gh issue close N` and
+  `git mv docs/issues/internal/N-name.md docs/issues/internal/done/`.
 
-### Creating New Issues
+## Numbering note
 
-1. **Internal Issue (all types):**
-   - Create file: `internal/{next-number}-{short-title}.md`
-   - Update the **Active** table in this README with the issue entry
-   - Set Public column to `-` initially
-
-2. **Publishing to GitHub (features/enhancements only):**
-   - Assign next PUB- number in mapping.json
-   - Update Public column in this README
-   - Create GitHub issue with PUB- number
-   - Never publish: bugs, security issues, internal tasks
-
-### Closing an Issue
-
-When an issue reaches `✅ Implemented` (or is otherwise closed), the last step of the close workflow is:
-
-1. `git mv docs/issues/internal/{file}.md docs/issues/internal/done/`
-2. Move the row from the **Active** table to the **Done** table in this README and update the link path to `internal/done/...`.
-3. Commit the archive move together with the status change.
-
-Rationale: `ls docs/issues/internal/` then shows only active work, matching the signal the operator expects. Rejected alternatives (status-per-folder, year-based archive) would cause churn or fragmentation for little gain.
-
-### Issue Types
-
-- **Feature**: New functionality (can be public)
-- **Enhancement**: Improvement to existing features (can be public)
-- **Bug Fix**: Fixing broken functionality (internal only)
-- **Security**: Security-related issues (internal only)
-- **Plugin**: Plugin-specific features (selective public)
-
-### Status Legend
-
-- 📋 Open - Issue is open and needs work
-- 🔄 In Progress - Issue is being actively worked on
-- ✅ Implemented - Issue has been completed and implemented (file lives in `internal/done/`)
-- ❌ Closed - Issue has been closed without implementation (file lives in `internal/done/`)
-- ⏸️ On Hold - Issue is temporarily paused
-
-### Priority Legend
-
-- **Critical** - Must be fixed immediately
-- **High** - Important feature or significant bug
-- **Medium** - Nice to have feature or minor bug
-- **Low** - Enhancement or cosmetic issue
-
-## Publishing Guidelines
-
-✅ **Can be published to GitHub:**
-
-- New features
-- Enhancements
-- Feature requests
-- Roadmap items
-- Success stories
-
-❌ **Keep internal only:**
-
-- Bug reports and fixes
-- Security vulnerabilities
-- Performance issues
-- Critical errors
-- Internal refactoring
-- Technical debt
+Filenames from the adoption of the GitHub-first model onward use the **GitHub
+issue number**. Legacy internal-only numbers `001`–`017` (in
+`internal/done/`) were never mirrored to GitHub and are kept for history only.

--- a/docs/issues/internal/013-typescript-preferences.md
+++ b/docs/issues/internal/013-typescript-preferences.md
@@ -1,4 +1,4 @@
-# Issue #013: User preferences storage — TypeScript first implementation
+# Issue #13: User preferences storage — TypeScript first implementation
 
 **Type**: Feature
 **Priority**: Medium
@@ -7,6 +7,7 @@
 **Labels**: feature, typescript, react, preferences, settings, multi-language
 **Repository**: Api
 **Related**: ADR-004 (User Preferences Storage Interface), Issue #012 (TypeScript `log` module)
+**GitHub**: #13
 
 ## Summary
 

--- a/docs/issues/internal/done/010-fuzzy-package-levenshtein.md
+++ b/docs/issues/internal/done/010-fuzzy-package-levenshtein.md
@@ -195,7 +195,7 @@ module reaches v2 it would become `github.com/cassandragargoyle/api/go/v2`.
 
 ## References
 
-- [Issue #006: Restructure project layout for multi-language platform](done/006-restructure-multi-language-layout-mvp.md)
-- [Issue #005: Python TelemetryProvider shared module](done/005-python-telemetry-provider.md)
+- [Issue #23: Restructure project layout for multi-language platform](done/023-restructure-multi-language-layout-mvp.md)
+- [Issue #22: Python TelemetryProvider shared module](done/022-python-telemetry-provider.md)
   — precedent for a Java↔Python parity package
 - [Wikipedia: Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)

--- a/docs/issues/internal/done/011-graph-view-contract.md
+++ b/docs/issues/internal/done/011-graph-view-contract.md
@@ -1,4 +1,4 @@
-# #011 — Graph View Contract: JSON Schema + File Extension for the 3D Node-Graph Viewer
+# Issue #11: Graph View Contract: JSON Schema + File Extension for the 3D Node-Graph Viewer
 
 **Status:** ✅ Implemented
 **Priority:** Medium
@@ -6,6 +6,7 @@
 **Labels:** contract, schema, graph, visualization
 **Created:** 2026-06-28
 **Closed:** 2026-06-29
+**GitHub**: #11
 
 ---
 
@@ -35,7 +36,7 @@ origin. Today the shape lives informally in the plugin's `model.py` and in the
 hand-written `app.js`. Promoting it to an Api contract gives every language
 (Python plugin, TypeScript component, future Go/Java callers) one validated,
 versioned definition — exactly as done for the VIM and plugin-platform schemas
-(see #009).
+(see #26).
 
 ## Distinct from the existing `*.graph.json` (2D)
 
@@ -125,7 +126,7 @@ Once chosen, the token should be:
 
 ## Related
 
-- Api #009 — Plugin Platform Contract Schemas (schema layout / conventions)
+- Api #26 — Plugin Platform Contract Schemas (schema layout / conventions)
 - portunix-plugins #086 — `graphlens` plugin (consumer; `model.py` builds it, `viewer.py` serves it)
 - portunix-vscode #050 — `GraphLens3D` React component (consumer; renderer)
 - portunix-vscode #030 — 2D Graph Canvas `*.graph.json` (the format this one must stay distinct from)

--- a/docs/issues/internal/done/012-typescript-log-module.md
+++ b/docs/issues/internal/done/012-typescript-log-module.md
@@ -1,4 +1,4 @@
-# Issue #012: Add TypeScript (`typescript/`) module with `log` package
+# Issue #12: Add TypeScript (`typescript/`) module with `log` package
 
 **Type**: Feature
 **Priority**: Medium
@@ -7,6 +7,7 @@
 **Closed**: 2026-07-06
 **Labels**: feature, typescript, react, log, logging, multi-language
 **Repository**: Api
+**GitHub**: #12
 
 ## Summary
 
@@ -38,7 +39,7 @@ window, and a webview panel all emit the project-standard log line.
 This establishes the `typescript/` module so future shared code (utilities,
 contract types, fuzzy matching) can be added alongside `log` without another
 restructuring — matching the precedent set by
-[#006](done/006-restructure-multi-language-layout-mvp.md) for `go/` and
+[#23](done/023-restructure-multi-language-layout-mvp.md) for `go/` and
 [#010](done/010-fuzzy-package-levenshtein.md) for adding a package across
 languages.
 
@@ -262,7 +263,7 @@ reverse.)
 1. **npm distribution.** Local `npm pack` + file dependency for v1, or set up a
    GitHub Packages npm feed now? (Leaning: local pack for v1; registry is a
    follow-up, mirroring how Java started before GitHub Packages in
-   [#002](done/002-github-packages-publishing.md).)
+   [#19](done/019-github-packages-publishing.md).)
 2. **Test runner / linter.** Vitest + ESLint/Prettier vs Biome — pick to match
    whatever portunix-vscode already uses so contributors share one toolchain.
 3. **Version alignment.** Reuse the repo's `1.0.0.9` scheme, or start the npm
@@ -272,11 +273,11 @@ reverse.)
 
 - [Java log package README](../../../java/src/main/java/org/cassandragargoyle/api/log/README.md)
   — the surface this module mirrors
-- [Issue #006: Restructure project layout for multi-language platform](done/006-restructure-multi-language-layout-mvp.md)
+- [Issue #23: Restructure project layout for multi-language platform](done/023-restructure-multi-language-layout-mvp.md)
   — precedent for adding a top-level language module (`go/`)
 - [Issue #010: Add `fuzzy` package (Java, Go, Python)](done/010-fuzzy-package-levenshtein.md)
   — precedent for a cross-language package with shared test vectors
-- [Issue #005: Python TelemetryProvider shared module](done/005-python-telemetry-provider.md)
+- [Issue #22: Python TelemetryProvider shared module](done/022-python-telemetry-provider.md)
   — precedent for a Java↔Python parity package
 - [portunix-vscode README](https://github.com/CassandraGargoyle/portunix-vscode)
   — first consumer (Pilot UI `src/pilot/`, VS Code extension `src/vscode-extension/`)

--- a/docs/issues/internal/done/014-opportunity-management-contracts.md
+++ b/docs/issues/internal/done/014-opportunity-management-contracts.md
@@ -1,4 +1,4 @@
-# Issue #014: Opportunity Management contract schemas
+# Issue #14: Opportunity Management contract schemas
 
 **Type**: Feature
 **Priority**: Medium
@@ -8,6 +8,7 @@
 **Labels**: contract, schema, opportunity-management, iso16355, pft, multi-language
 **Repository**: Api
 **Related**: ADR-008 (Opportunity Management — portunix-architecture),
+**GitHub**: #14
 portunix #196 (ptx-pft `pft ideas`), portunix-vscode #092 (Pilot gallery),
 Issue #011 (Graph View Contract — reused for the backlog graph)
 **Extended by**: #015 (v2 model — Venture/Initiative/Use-Case/Epic/Team/Backlog/Product;

--- a/docs/issues/internal/done/015-opportunity-management-v2-entities.md
+++ b/docs/issues/internal/done/015-opportunity-management-v2-entities.md
@@ -1,4 +1,4 @@
-# Issue #015: Opportunity Management v2 — Venture / Initiative / Use-Case / Epic / Team / Product contracts
+# Issue #15: Opportunity Management v2 — Venture / Initiative / Use-Case / Epic / Team / Product contracts
 
 **Type**: Feature
 **Priority**: Medium
@@ -8,6 +8,7 @@
 **Labels**: contract, schema, opportunity-management, use-case, initiative, epic, team, product, iso16355, pft, multi-language
 **Repository**: Api
 **Related**: #014 (Opportunity Management contracts v1 — extended by this issue),
+**GitHub**: #15
 ADR-008 (Opportunity Management — portunix-architecture),
 portunix #197 (ptx-pft `pft ideas` v2), portunix-vscode #098 (Pilot v2 GUI),
 #011 (Graph View Contract — reused for both backlogs)

--- a/docs/issues/internal/done/016-discussion-contract-v3-structured.md
+++ b/docs/issues/internal/done/016-discussion-contract-v3-structured.md
@@ -1,4 +1,4 @@
-# Issue #016: Discussion contract v3.0.0 — structured, multi-actor threads
+# Issue #16: Discussion contract v3.0.0 — structured, multi-actor threads
 
 **Type**: Feature
 **Priority**: Medium
@@ -8,6 +8,7 @@
 **Labels**: contract, schema, opportunity-management, discussion, chat, multi-actor, provenance, breaking-change
 **Repository**: Api
 **Related**: #015 (Opportunity Management v2 entities — `discussion.schema.json`
+**GitHub**: #16
 v2.0.0 introduced there), #014 (Opportunity Management contracts v1),
 ADR-008 (Opportunity Management — portunix-architecture),
 portunix-vscode #099 (Pilot `VentureDiscussionView` — consumer of this contract),

--- a/docs/issues/internal/done/017-product-vendor-ownership.md
+++ b/docs/issues/internal/done/017-product-vendor-ownership.md
@@ -1,4 +1,4 @@
-# Issue #017: Product schema — optional vendor / owner organization reference
+# Issue #17: Product schema — optional vendor / owner organization reference
 
 **Type**: Enhancement
 **Priority**: Medium
@@ -7,6 +7,7 @@
 **Labels**: contract, schema, product, opportunity-management, federation
 **Repository**: Api
 **Related**: #015 (Opportunity Management v2 — introduced `product.schema.json`)
+**GitHub**: #17
 
 ## Summary
 

--- a/docs/issues/internal/done/018-github-packages.md
+++ b/docs/issues/internal/done/018-github-packages.md
@@ -1,4 +1,4 @@
-# Issue #001: Github packages
+# Issue #18: Github packages
 
 **Type**: Feature (design / discussion)
 **Priority**: Medium
@@ -6,9 +6,10 @@
 **Created**: 2026-02-11
 **Closed**: 2026-04-19
 **Labels**: architecture, maven, github-packages
-**Related**: #002
-**Superseded by**: #002 (concrete publishing workflow)
+**Related**: #19
+**Superseded by**: #19 (concrete publishing workflow)
 **Repository**: Api
+**GitHub**: #18
 
 ## Closure note
 
@@ -20,7 +21,7 @@ criteria of its own.
 The concrete implementation — `distributionManagement`, the
 `.github/workflows/publish.yml` release pipeline, and the first
 published version — landed in issue
-[#002](done/002-github-packages-publishing.md) and is in production.
+[#19](done/019-github-packages-publishing.md) and is in production.
 Follow-up topics listed at the bottom of this document (BOM module,
 CODEOWNERS, semver/changelog automation, consumer-driven contract
 tests, etc.) are out of scope here; open a new issue if any of them

--- a/docs/issues/internal/done/019-github-packages-publishing.md
+++ b/docs/issues/internal/done/019-github-packages-publishing.md
@@ -1,4 +1,4 @@
-# Issue #002: GitHub Packages publishing workflow
+# Issue #19: GitHub Packages publishing workflow
 
 **Type**: Feature
 **Priority**: Medium
@@ -6,13 +6,14 @@
 **Closed**: 2026-03-01
 **Created**: 2026-03-01
 **Labels**: ci, maven, github
-**Related**: #001
+**Related**: #18
 **GitHub Issue**: [cassandragargoyle/api#6](https://github.com/cassandragargoyle/api/issues/6)
 **Repository**: Api
+**GitHub**: #19
 
 ## Description
 
-Implement GitHub Packages publishing for CassandraGargoyle API artifacts. This is the concrete implementation task derived from the architecture decisions in #001.
+Implement GitHub Packages publishing for CassandraGargoyle API artifacts. This is the concrete implementation task derived from the architecture decisions in #18.
 
 ## Tasks
 

--- a/docs/issues/internal/done/020-fix-persistance-typo.md
+++ b/docs/issues/internal/done/020-fix-persistance-typo.md
@@ -1,4 +1,4 @@
-# Issue #003: Fix "persistance" typo to "persistence"
+# Issue #20: Fix "persistance" typo to "persistence"
 
 **Type**: Bug Fix
 **Priority**: Low
@@ -8,6 +8,7 @@
 **Labels**: refactoring, naming
 **Repository**: Api
 **Reported by**: Adam
+**GitHub**: #20
 
 ## Description
 

--- a/docs/issues/internal/done/021-opentelemetry-telemetry-provider.md
+++ b/docs/issues/internal/done/021-opentelemetry-telemetry-provider.md
@@ -1,4 +1,4 @@
-# Issue #004: OpenTelemetry TelemetryProvider utility class
+# Issue #21: OpenTelemetry TelemetryProvider utility class
 
 **Type**: Feature
 **Priority**: Medium
@@ -8,6 +8,7 @@
 **Labels**: feature, observability, opentelemetry, tracing
 **Related**: portunix-plugins#050, ADR-016
 **Repository**: Api
+**GitHub**: #21
 
 ## Description
 

--- a/docs/issues/internal/done/022-python-telemetry-provider.md
+++ b/docs/issues/internal/done/022-python-telemetry-provider.md
@@ -1,16 +1,17 @@
-# Issue #005: Python TelemetryProvider shared module
+# Issue #22: Python TelemetryProvider shared module
 
 **Type**: Feature
 **Priority**: Medium
 **Status**: ✅ Implemented
 **Created**: 2026-03-19
 **Labels**: feature, observability, opentelemetry, tracing, logging, python
-**Related**: API#004 (Java TelemetryProvider), portunix-reco#INT-002
+**Related**: API#21 (Java TelemetryProvider), portunix-reco#INT-002
 **Repository**: Api
+**GitHub**: #22
 
 ## Description
 
-Create a shared Python `TelemetryProvider` module in the API project (`cassandragargoyle.api.telemetry`) that mirrors the functionality of the existing Java `TelemetryProvider` (Issue #004). Additionally, provide standard logging utilities (`cassandragargoyle.api.log`) mirroring the Java `LogFactory` and `Logging` classes. These modules will be used by all Python-based Portunix components (starting with portunix-reco) to provide centralized OpenTelemetry TracerProvider initialization and unified logging.
+Create a shared Python `TelemetryProvider` module in the API project (`cassandragargoyle.api.telemetry`) that mirrors the functionality of the existing Java `TelemetryProvider` (Issue #21). Additionally, provide standard logging utilities (`cassandragargoyle.api.log`) mirroring the Java `LogFactory` and `Logging` classes. These modules will be used by all Python-based Portunix components (starting with portunix-reco) to provide centralized OpenTelemetry TracerProvider initialization and unified logging.
 
 This is a prerequisite for portunix-reco Issue INT-002 (OpenTelemetry tracing).
 
@@ -241,7 +242,7 @@ dd/MM/yyyy HH:mm:ss.SSS LEVEL [logger.name]: message
 
 ### 5. Design principles
 
-- **1:1 parity with Java TelemetryProvider** (Issue #004) - same builder pattern, same ExporterType enum, same behavior
+- **1:1 parity with Java TelemetryProvider** (Issue #21) - same builder pattern, same ExporterType enum, same behavior
 - **Zero overhead when disabled**: `no_op()` returns OTel NoOp tracer, no SDK initialization
 - **Thread-safe**: singleton-safe TracerProvider
 - **Standard OTel env vars**: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_EXPORTER` override programmatic config
@@ -257,7 +258,7 @@ dd/MM/yyyy HH:mm:ss.SSS LEVEL [logger.name]: message
 5. `shutdown()` flushes pending spans before application exit
 6. Unit tests cover all three modes (NoOp, Console, OTLP)
 7. Package is installable via pip (editable mode at minimum)
-8. API surface mirrors Java TelemetryProvider (#004) for cross-language consistency
+8. API surface mirrors Java TelemetryProvider (#21) for cross-language consistency
 9. `LogFactory.get_logger()` returns a properly named `logging.Logger`
 10. `Logging.initialize()` configures console and/or file handlers with custom formatter
 11. `Logging.set_log_level()` accepts string aliases (TRACE/DEBUG/INFO/WARNING/ERROR and shorthand T/D/I/W/E and numeric 0-4)
@@ -283,6 +284,6 @@ dd/MM/yyyy HH:mm:ss.SSS LEVEL [logger.name]: message
 
 ## References
 
-- [Issue #004: Java TelemetryProvider](004-opentelemetry-telemetry-provider.md) - reference implementation
+- [Issue #21: Java TelemetryProvider](021-opentelemetry-telemetry-provider.md) - reference implementation
 - [OpenTelemetry Python SDK](https://opentelemetry.io/docs/languages/python/)
 - [OpenTelemetry Python API Reference](https://opentelemetry-python.readthedocs.io/)

--- a/docs/issues/internal/done/023-restructure-multi-language-layout-mvp.md
+++ b/docs/issues/internal/done/023-restructure-multi-language-layout-mvp.md
@@ -1,4 +1,4 @@
-# Issue #006: Restructure project layout for multi-language platform and first MVP adjustments
+# Issue #23: Restructure project layout for multi-language platform and first MVP adjustments
 
 **Type**: Feature
 **Priority**: High
@@ -7,6 +7,7 @@
 **Labels**: architecture, restructuring, mvp, unified-platform
 **Related**: ADR-002 (Unified AI Platform Transition), portunix-architecture ADR-001
 **Repository**: Api
+**GitHub**: #23
 
 ## Problem
 
@@ -83,7 +84,7 @@ api/                              # Repo root (parent POM)
 - [ ] **1.8** Update documentation
   - `README.md` - update project structure section
   - `CLAUDE.md` - update any path references
-  - Issue #005 - note that file paths have changed (add migration note)
+  - Issue #22 - note that file paths have changed (add migration note)
 - [ ] **1.9** Clean up `.egg-info` and `__pycache__` artifacts left in old location
 
 ### Phase 2: Add contract directory (MVP foundation)

--- a/docs/issues/internal/done/024-remove-persistence-module.md
+++ b/docs/issues/internal/done/024-remove-persistence-module.md
@@ -1,4 +1,4 @@
-# Issue #007: Remove persistence module
+# Issue #24: Remove persistence module
 
 **Type**: Feature
 **Priority**: Medium
@@ -7,6 +7,7 @@
 **Labels**: architecture, cleanup, unified-platform
 **Related**: ADR-003 (Remove Persistence Module), ADR-002 (Unified AI Platform Transition)
 **Repository**: Api
+**GitHub**: #24
 
 ## Problem
 

--- a/docs/issues/internal/done/025-python-build-and-publish-pipeline.md
+++ b/docs/issues/internal/done/025-python-build-and-publish-pipeline.md
@@ -1,4 +1,4 @@
-# Issue #008: Python build and publish pipeline
+# Issue #25: Python build and publish pipeline
 
 **Type**: Feature
 **Priority**: Medium
@@ -6,8 +6,9 @@
 **Created**: 2026-03-19
 **Closed**: 2026-03-19
 **Labels**: python, ci, build, distribution
-**Related**: Issue #005 (Python TelemetryProvider), Issue #006 (Restructure)
+**Related**: Issue #22 (Python TelemetryProvider), Issue #23 (Restructure)
 **Repository**: Api
+**GitHub**: #25
 
 ## Problem
 

--- a/docs/issues/internal/done/026-plugin-platform-contract-schemas.md
+++ b/docs/issues/internal/done/026-plugin-platform-contract-schemas.md
@@ -1,4 +1,4 @@
-# Issue #009: Plugin Platform Contract Schemas
+# Issue #26: Plugin Platform Contract Schemas
 
 **Type**: Feature
 **Priority**: High
@@ -6,6 +6,7 @@
 **Created**: 2026-03-21
 **Labels**: architecture, contract, plugin-platform
 **Related**: portunix-architecture ADR-001 (Unified AI Plugin & Task Platform), API ADR-002
+**GitHub**: #26
 
 ## Summary
 


### PR DESCRIPTION
Adopts the GitHub-first issue model (inspired by portunix-plugins) and aligns internal issue files with GitHub issue numbers.

## Workflow change
- `docs/contributing/ISSUE-MANAGEMENT.md` and `docs/issues/README.md` rewritten to the **GitHub-first** model: GitHub assigns `N`, the GitHub issue holds only a short description + a link to `docs/issues/internal/N-*.md`, no overview tables.
- New `/create-issue` skill (English) automates the flow.
- `/implement-issue` updated for the GitHub `origin` (dropped Gitea and deleted publish-script references).
- `create-manifest` skill translated to English.

## Numbering alignment
- Internal issues **011–017** mirrored to GitHub **#11–#17** (only #13 stays open; the rest are closed). Files keep their numbers; each gains a `**GitHub**: #N` field.
- Legacy issues **001–009** renumbered to **018–026** and mirrored to GitHub **#18–#26** (closed). Cross-references updated.
- `010` (fuzzy) is covered by sync PR #10 and left as-is.

## Notes
- No code changes — docs, skills, and issue detail files only.

Closes #13 is intentionally **not** used — #13 stays open (active work).